### PR TITLE
Minor changes

### DIFF
--- a/lib/Hostfile/Manager.pm
+++ b/lib/Hostfile/Manager.pm
@@ -76,7 +76,7 @@ sub status_helper
 	$fragment =~ s{^$path_prefix}{};
 
 	my $found = $hostfile =~ /@{[block($fragment)]}/;
-	my $flag = $found ? ($1 eq "$fragment_contents\n" ? "+" : "*") : " ";
+	my $flag = $found ? ($1 eq $fragment_contents ? "+" : "*") : " ";
 	print "$flag $fragment\n";
 }
 


### PR DESCRIPTION
Anthony,

You were treating perl lists as PHP arrays, which will not work as you expect.  The short of it is that you either need to consume the whole list (as I have done) or pass the array by reference (e.g. enable_fragments(\@enable)) and then either treat it as an arrayref or dereference it in the method.

I also tweaked the fragment status code a trifle.

-Eric
